### PR TITLE
Rewrite library with stateful `Environment` to conform with RL concepts

### DIFF
--- a/examples/example.jl
+++ b/examples/example.jl
@@ -25,119 +25,131 @@ md"""
 
 # ╔═╡ 5ff9a070-12a3-45fd-a1b4-b619998e468a
 md"""
-## Deadline hit/miss patterns
+## Defining the policy π
 
-Ideal actions are all deadline hits:
+The reference policy π₀ is defined as meeting all deadlines:
 """
 
 # ╔═╡ 2fd32b80-1d52-4a97-8dab-46f1278ebc58
-ideal_actions = ones(Bool, 100)
+π₀(state::Vector{Float64}, reward::Float64)::Bool = true
 
 # ╔═╡ 05117c1b-a715-44f4-9f98-c7fbca48ce30
 md"""
 **You only need to change the section below.**
-Choose one of the strategies, or define your own strategy here.
+
+Define your own policy here.
+The rewards is currently defined as the negation of distance between current
+state and the state obtained by following the reference policy π₀
 """
 
 # ╔═╡ fac6522b-c189-4b7c-be35-11d038a854bc
-## Some pre-defined strategies
-# actions = ones(Bool, 100) 				# All deadlines are **met**
-# actions = zeros(Bool, 100)				# All deadlines are **missed**
-actions = repeat([false, false, true], 33) 	# Deadlines are met every third period
+function π(state::Vector{Float64}, reward::Float64)::Bool
+	# For example, return true when the distance to reference is greater than 1
+	return reward <= -1
+end
 
-## Or define your own strategy below
+# ╔═╡ 8015eee9-cfe9-4890-a3a5-e3f97517d1d2
+md"""
+!!! note
 
+	Some of the policies are defined with the [compact function declaration syntax](https://docs.julialang.org/en/v1/manual/functions/#man-functions), which is equivalent to the normal syntax. I.e., the following two declarations are equivalent:
+	```julia
+	π₀(state::Vector{Float64}, reward::Float64)::Bool = true
+	```
+	and
+	```julia
+	function π₀(state::Vector{Float64}, reward::Float64)::Bool
+		return true
+	end
+	```
+!!! note
+	The symbol "π" can be entered by typing `\pi` followed by the `<tab>` key. This is a nice feature of Julia and can be used to enter [any UNICODE character](https://docs.julialang.org/en/v1/manual/unicode-input/)! Under the hood, this is possible because Julia allows UNICODE characters to be part of function names and variable names in addition to the ASCII characters.
+"""
 
 # ╔═╡ c57331ac-ea8e-44b9-9213-9cad71788244
 md"""
 ## Outputs
 
-Defining the initial state
+Define the sampling period $T$ and time horizon $H$
 """
+
+# ╔═╡ 311337a7-9402-4ade-8707-e9ba9b72fa3b
+const T = 0.02
+
+# ╔═╡ 837c7cf2-66cb-4ebe-a417-df1e5da9cc73
+const H = 100
+
+# ╔═╡ 2fee3edd-bba5-4738-a43c-691c9b4cf3de
+md"""
+Initiate the simulation environment
+"""
+
+# ╔═╡ a274cbd6-13c3-499f-8407-41211e25dae1
+sys = c2d(benchmarks[:F1], T)
 
 # ╔═╡ 4f63bf67-8208-4742-8dee-aa3186c8d658
-x0 = make_x0()
+env = let π
+	Environment(sys)
+end
 
-# ╔═╡ d9b853f3-4f79-487e-98ef-2f1b321b9d69
+# ╔═╡ e8e8964c-c829-4ba4-8cbb-230eec2faffa
 md"""
-Trajectory of the system dynamics following the defined actions
+Simulate the system for $H$ steps
 """
+
+# ╔═╡ cbd51753-b04a-40c9-8f5b-9b88c74fc6f7
+states, rewards, ideal_states = sim!(env, π, H)
+
+# ╔═╡ 09e3258a-a3fe-43a0-8f65-0d4a13b5c513
+md"""
+Calculate the total rewards over $H=$ $H steps
+"""
+
+# ╔═╡ 45b657ae-6220-44b3-aa35-cae27bf730b0
+total_rewards = sum(rewards)
 
 # ╔═╡ eb39929a-46b6-4d53-a3e9-30af17500b54
 md"""
-Trajectory of the system dynamics following the ideal actions.
+Plot the trajectory of system dynamics following the reference policy.
+"""
+
+# ╔═╡ d9b853f3-4f79-487e-98ef-2f1b321b9d69
+md"""
+Plot the trajectory of system dynamics following the defined policy.
 """
 
 # ╔═╡ ad589207-0f42-446a-b3d6-167a54c02950
 md"""
-The devition between defined actions and ideal actions
+Plot the rewards (distance to the reference trajectory).
 """
 
 # ╔═╡ e705f0df-bdcc-4673-976f-5d096c6a2abc
 md"""
-## Bootstrapping
-
-The rest of the notebook is bootstrapping the simulation of the plant's dynamics.
+## Helper functions
 """
-
-# ╔═╡ 2ae91dac-85c2-4fb1-9a08-251dc16f55ca
-"""
-	simH(x0, action)
-
-Simulate the system dynamics over time horizon H, starting from the initial
-state `x0`. `actions` is assumed to have length H.
-"""
-function simH(x0::Vector{Float64}, actions::Vector{Bool})
-	x = [x0]
-	for σ ∈ actions
-		push!(x, sim(x[end], σ))
-	end
-	x
-end
-
-# ╔═╡ d08f8523-1c9e-4508-8ba6-b3c0165384a7
-"""
-	devH(x0, actions; ideal_actions)
-
-Compute the deviations between the system dynamics following the defined actions
-and the ideal actions. Default for the optional argument `ideal_actions` is all 
-deadline hits.
-"""
-function devH(
-		x0::Vector{Float64}, 
-		actions::Vector{Bool}; 
-		ideal_actions=ones(Bool, length(actions)))
-	x = simH(x0, actions)
-	ideal_x = simH(x0, ideal_actions)
-
-	# Take the difference per point between two trajectories, then take the norm
-	# of the difference over all dimensions.
-	(x .- ideal_x) .|> norm
-end
 
 # ╔═╡ 5402045e-83ef-4b90-9f14-1796fdadacc0
 """
 	plotH(x)
 
-Plot the system dynamics as recorded in state vector `x`.
+Plot the system states as recorded in states matrix.
 """
-function plotH(x::Vector{Vector{Float64}})
-	plot(0:length(x)-1, stack(x)')
+function plotH(states::Matrix{Float64})
+	# Transposing `states` because plot uses the first dimension as indices.
+	plot(0:size(states, 2) - 1, states')
 end
 
-# ╔═╡ 599e9ada-5464-46ee-9736-6ee4ee895f36
-function plotH(x::Vector{Float64})
-	plot(0:length(x)-1, x)
-end
+# ╔═╡ c34375b4-70ab-4468-9186-c43948f22a7a
+plotH(v::Vector{Float64}) = plotH(reshape(v, 1, :))
 
 # ╔═╡ 19634c38-ec2c-45a0-862a-3f92beecb5a1
-simH(x0, actions) |> plotH
+plotH(ideal_states)
 
 # ╔═╡ 66fbe369-33e7-409f-ae66-29c1984518b3
-simH(x0, ideal_actions) |> plotH
+plotH(states)
 
-# ╔═╡ ca73918e-8c00-49d8-a895-70174bfbebe9
-devH(x0, actions) |> plotH
+# ╔═╡ 7c54f79a-6bb4-4190-ab13-bca71bb868a8
+plotH(rewards)
 
 # ╔═╡ Cell order:
 # ╟─abb82687-12f0-4754-b3dd-49c03f3c9ad1
@@ -146,16 +158,23 @@ devH(x0, actions) |> plotH
 # ╠═2fd32b80-1d52-4a97-8dab-46f1278ebc58
 # ╟─05117c1b-a715-44f4-9f98-c7fbca48ce30
 # ╠═fac6522b-c189-4b7c-be35-11d038a854bc
+# ╟─8015eee9-cfe9-4890-a3a5-e3f97517d1d2
 # ╟─c57331ac-ea8e-44b9-9213-9cad71788244
+# ╠═311337a7-9402-4ade-8707-e9ba9b72fa3b
+# ╠═837c7cf2-66cb-4ebe-a417-df1e5da9cc73
+# ╟─2fee3edd-bba5-4738-a43c-691c9b4cf3de
+# ╠═a274cbd6-13c3-499f-8407-41211e25dae1
 # ╠═4f63bf67-8208-4742-8dee-aa3186c8d658
-# ╟─d9b853f3-4f79-487e-98ef-2f1b321b9d69
+# ╟─e8e8964c-c829-4ba4-8cbb-230eec2faffa
+# ╠═cbd51753-b04a-40c9-8f5b-9b88c74fc6f7
+# ╟─09e3258a-a3fe-43a0-8f65-0d4a13b5c513
+# ╠═45b657ae-6220-44b3-aa35-cae27bf730b0
+# ╠═eb39929a-46b6-4d53-a3e9-30af17500b54
 # ╠═19634c38-ec2c-45a0-862a-3f92beecb5a1
-# ╟─eb39929a-46b6-4d53-a3e9-30af17500b54
+# ╟─d9b853f3-4f79-487e-98ef-2f1b321b9d69
 # ╠═66fbe369-33e7-409f-ae66-29c1984518b3
 # ╟─ad589207-0f42-446a-b3d6-167a54c02950
-# ╠═ca73918e-8c00-49d8-a895-70174bfbebe9
+# ╠═7c54f79a-6bb4-4190-ab13-bca71bb868a8
 # ╟─e705f0df-bdcc-4673-976f-5d096c6a2abc
-# ╠═2ae91dac-85c2-4fb1-9a08-251dc16f55ca
-# ╟─d08f8523-1c9e-4508-8ba6-b3c0165384a7
 # ╠═5402045e-83ef-4b90-9f14-1796fdadacc0
-# ╠═599e9ada-5464-46ee-9736-6ee4ee895f36
+# ╠═c34375b4-70ab-4468-9186-c43948f22a7a

--- a/src/ControlRL.jl
+++ b/src/ControlRL.jl
@@ -1,6 +1,6 @@
 module ControlRL
 
-export Environment, step, state, reward, sim
+export Environment, step!, state, reward, sim!
 include("sim.jl")
 
 export benchmarks, c2d

--- a/src/ControlRL.jl
+++ b/src/ControlRL.jl
@@ -1,6 +1,9 @@
 module ControlRL
 
-export sim, sim!, make_x0
+export Environment, step, state, reward, sim
 include("sim.jl")
+
+export benchmarks, c2d
+include("models.jl")
 
 end

--- a/src/models.jl
+++ b/src/models.jl
@@ -1,0 +1,96 @@
+using ControlSystemsBase: ss, tf, c2d
+using LinearAlgebra: I
+
+# Resistor-capacitor network
+sys_rcn = let
+	r_1 = 100000
+	r_2 = 500000
+	r_3 = 200000
+	c_1 = 0.000002
+	c_2 = 0.000010
+	A = [-1/c_1 * (1/r_1 + 1/r_2)  1/(r_2*c_1)
+	     1/(r_2*c_2)               -1/c_2 * (1/r_2 + 1/r_3)]
+	B = [1/(r_1*c_1)
+	     1/(r_3*c_2)]
+	# C = [1  -1]
+    C = I
+	D = 0
+
+	ss(A, B, C, D)
+end
+
+# F1-tenth car
+sys_f1t = let 
+    v = 6.5
+    L = 0.3302
+    d = 1.5
+    A = [0 v ; 0 0]
+    B = [0; v/L]
+    C = [1 0]
+    D = 0
+
+    ss(A, B, C, D)
+end
+
+# DC motor
+sys_dcm = let
+    A = [-10 1; -0.02 -2]
+    B = [0; 2]
+    C = [1 0]
+    D = 0
+
+    ss(A, B, C, D)
+end
+
+# Car suspension system
+sys_css = let
+    A = [0. 1 0 0; -8 -4 8 4; 0 0 0 1; 80 40 -160 -60]
+    B = [0; 80; 20; -1120]
+    C = [1 0 0 0]
+    D = 0
+
+    ss(A, B, C, D)
+end
+
+# Electronic wedge brake
+sys_ewb = let
+    A = [0 1; 8.3951e3 0]
+    B = [0; 4.0451]
+    C = [7.9920e3 0]
+    D = 0
+
+    ss(A, B, C, D)
+end
+
+# Cruise control 1
+sys_cc1 = let
+    A = -0.05
+    B = 0.01
+    C = 1
+    D = 0
+
+    ss(A, B, C, D)
+end
+
+# Cruise control 2
+sys_cc2 = let
+    A = [0 1 0; 0 0 1; -6.0476 -5.2856 -0.238]
+    B = [0; 0; 2.4767]
+    C = [1 0 0]
+    D = 0
+
+    ss(A, B, C, D)
+end
+
+sys_mpc = ss(tf([3, 1],[1, 0.6, 1]))
+
+benchmarks = Dict([
+    :RC => sys_rcn,
+    :F1 => sys_f1t,
+    :DC => sys_dcm,
+    :CS => sys_css,
+    :EW => sys_ewb,
+    :C1 => sys_cc1,
+    :CC => sys_cc2,
+    :MPC => sys_mpc
+])

--- a/src/sim.jl
+++ b/src/sim.jl
@@ -19,11 +19,11 @@ function Environment(sys::StateSpace{<:Discrete})
 end
 
 """
-    step(env, action)
+    step!(env, action)
 
 Simulate the plant's dynamics for one step, according to the action `action` (true for hitting the deadline, false for missing it).
 """
-function step(env::Environment, action::Bool)
+function step!(env::Environment, action::Bool)
     env.state = if action
         env.sys.A * env.state - env.sys.B * env.K * env.state
     else
@@ -40,7 +40,7 @@ end
 Simulate the environment for `H` steps using policy `π`.
 Returns two vectors containing the states and rewards for each step.
 """
-function sim(env::Environment, π::Function, H::Int)
+function sim!(env::Environment, π::Function, H::Int)
     states = Vector{Vector{Float64}}(undef, H + 1)
     rewards = Vector{Float64}(undef, H + 1)
     
@@ -49,7 +49,7 @@ function sim(env::Environment, π::Function, H::Int)
     
     for t in 1:H
         action = π(states[t], rewards[t])
-        states[t + 1], rewards[t + 1] = step(env, action)
+        states[t + 1], rewards[t + 1] = step!(env, action)
     end
     
     return stack(states), rewards

--- a/src/sim.jl
+++ b/src/sim.jl
@@ -6,7 +6,7 @@ mutable struct Environment
     sys::StateSpace{<:Discrete}
     K::Matrix{Float64}
     state::Vector{Float64}
-    state_ideal::Vector{Float64}
+    ideal_state::Vector{Float64}
 end
 
 """
@@ -29,9 +29,9 @@ function step(env::Environment, action::Bool)
     else
         env.sys.A * env.state
     end
-    env.state_ideal = env.sys.A * env.state - env.sys.B * env.K * env.state
+    env.ideal_state = env.sys.A * env.ideal_state - env.sys.B * env.K * env.ideal_state
 
-    return state(env), reward(env)
+    return env.state, reward(env)
 end
 
 """
@@ -44,7 +44,7 @@ function sim(env::Environment, π::Function, H::Int)
     states = Vector{Vector{Float64}}(undef, H + 1)
     rewards = Vector{Float64}(undef, H + 1)
     
-    states[1] = state(env)
+    states[1] = env.state
     rewards[1] = reward(env)
     
     for t in 1:H
@@ -70,7 +70,7 @@ end
 Calculate the reward for the given environment at the current step.
 """
 function reward(env::Environment)
-    return -norm(env.state - env.state_ideal)
+    return -norm(env.state - env.ideal_state)
 end
 
 """

--- a/src/sim.jl
+++ b/src/sim.jl
@@ -43,16 +43,19 @@ Returns two vectors containing the states and rewards for each step.
 function sim!(env::Environment, π::Function, H::Int)
     states = Vector{Vector{Float64}}(undef, H + 1)
     rewards = Vector{Float64}(undef, H + 1)
+    ideal_states = Vector{Vector{Float64}}(undef, H + 1)
     
     states[1] = env.state
     rewards[1] = reward(env)
+    ideal_states[1] = env.ideal_state
     
     for t in 1:H
         action = π(states[t], rewards[t])
         states[t + 1], rewards[t + 1] = step!(env, action)
+        ideal_states[t + 1] = env.ideal_state
     end
     
-    return stack(states), rewards
+    return stack(states), rewards, stack(ideal_states)
 end
 
 """

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,2 @@
 [deps]
-Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,20 +1,25 @@
-using ControlRL
 using Test
 using Plots
+using ControlRL
 
 @testset "ControlRL.jl" begin
-    x0 = make_x0()
-    x = [x0]
-    for i in 1:100
-        push!(x, sim(x[end], true))
-    end
-    # Equivalent to `@test isapprox(x[end], zeros(size(x[end])), atol=1e-5)`
-    @test x[end] ≈ zeros(size(x[end])) atol=1e-5
-    
-    x_inplace = copy(x0)
-    for i in 1:100
-        sim!(x_inplace, true)
+    T = 0.1
+    sys = c2d(benchmarks[:F1], T)
+    env = Environment(sys)
+
+    H = 100
+    s, r = state(env), reward(env)
+    for t in 1:H
+        s, r = step(env, true)
     end
 
-    @test x_inplace == x[end]
+    # Equivalent to `@test isapprox(state, zeros(size(state)), atol=1e-5)`
+    @test s ≈ zeros(size(s)) atol=1e-5
+    @test r ≈ 0.0 atol=1e-5
+
+    env2 = Environment(sys)
+    states, rewards = sim(env2, (s, r) -> true, H)
+
+    @test states[:, end] == s
+    @test rewards[end] == r
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,4 @@
 using Test
-using Plots
 using ControlRL
 
 @testset "ControlRL.jl" begin
@@ -10,7 +9,7 @@ using ControlRL
     H = 100
     s, r = state(env), reward(env)
     for t in 1:H
-        s, r = step(env, true)
+        s, r = step!(env, true)
     end
 
     # Equivalent to `@test isapprox(state, zeros(size(state)), atol=1e-5)`
@@ -18,7 +17,7 @@ using ControlRL
     @test r ≈ 0.0 atol=1e-5
 
     env2 = Environment(sys)
-    states, rewards = sim(env2, (s, r) -> true, H)
+    states, rewards = sim!(env2, (s, r) -> true, H)
 
     @test states[:, end] == s
     @test rewards[end] == r


### PR DESCRIPTION
Rewrite the library with stateful environments, represented as mutable structs. This enables standard and intuitive function usage such as
```julia
step!(env::Environment, action::Bool)
```
and
```julia
state(env::Environment)
reward(env::Environment)
```
The agent is represented by a policy $\pi$(s, r), and a multistep simulation can be run as
```julia
sim!(env::Environment, π::Function, H::Integer)
```

The example notebook is also updated with the new syntax and usage.