### PR TITLE
Policy function π now has access to state, reward, and action history

### DIFF
--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -1,5 +1,7 @@
 [deps]
 ControlSystemsBase = "aaaaaaaa-a6ca-5380-bf3e-84a91bcd477e"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+PlotlyJS = "f0f68f2c-4968-5e81-91da-67840de0976a"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 PlutoUI = "7f904dfe-b85e-4ff6-b463-dae2292396a8"
+Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"

--- a/examples/example.jl
+++ b/examples/example.jl
@@ -33,7 +33,7 @@ The reference policy π₀ is defined as meeting all deadlines:
 """
 
 # ╔═╡ 2fd32b80-1d52-4a97-8dab-46f1278ebc58
-π₀(states::Vector{Vector{Float64}}, rewards::Vector{Float64})::Bool = true
+π₀(actions::Vector{Bool}, states::Vector{Vector{Float64}}, rewards::Vector{Float64}) = true
 
 # ╔═╡ 05117c1b-a715-44f4-9f98-c7fbca48ce30
 md"""
@@ -71,11 +71,11 @@ md"""
 
 	Some of the policies are defined with the [compact function declaration syntax](https://docs.julialang.org/en/v1/manual/functions/#man-functions), which is equivalent to the normal syntax. I.e., the following two declarations are equivalent:
 	```julia
-	π₀(states::Vector{Vector{Float64}}, rewards::Vector{Float64})::Bool = true
+	π₀(actions::Vector{Bool}, states::Vector{Vector{Float64}}, rewards::Vector{Float64}) = true
 	```
 	and
 	```julia
-	function π₀(states::Vector{Vector{Float64}}, rewards::Vector{Float64})::Bool
+	function π₀(actions::Vector{Bool}, states::Vector{Vector{Float64}}, rewards::Vector{Float64})
 		return true
 	end
 	```

--- a/examples/example.jl
+++ b/examples/example.jl
@@ -9,11 +9,13 @@ begin
 	import Pkg
 	Pkg.activate(".")
 	Pkg.instantiate()
-	push!(LOAD_PATH, "$(@__DIR__)/../src")
-	using ControlRL
+	using Revise
 	using Plots
+	plotlyjs()
 	using LinearAlgebra
 	using PlutoUI
+	push!(LOAD_PATH, "$(@__DIR__)/../src")
+	using ControlRL
 
 	TableOfContents()
 end
@@ -31,21 +33,36 @@ The reference policy π₀ is defined as meeting all deadlines:
 """
 
 # ╔═╡ 2fd32b80-1d52-4a97-8dab-46f1278ebc58
-π₀(state::Vector{Float64}, reward::Float64)::Bool = true
+π₀(states::Vector{Vector{Float64}}, rewards::Vector{Float64})::Bool = true
 
 # ╔═╡ 05117c1b-a715-44f4-9f98-c7fbca48ce30
 md"""
 **You only need to change the section below.**
 
 Define your own policy here.
-The rewards is currently defined as the negation of distance between current
-state and the state obtained by following the reference policy π₀
+The reward is currently defined as the negation of distance between current
+state and the state obtained by following the reference policy π₀.
+
+Several example policies are provided. Feel free to experiment with one of them,
+combine two or more of them, or experiment with your own policies!
 """
 
 # ╔═╡ fac6522b-c189-4b7c-be35-11d038a854bc
-function π(state::Vector{Float64}, reward::Float64)::Bool
-	# For example, return true when the distance to reference is greater than 1
-	return reward <= -1
+"""
+	π(actions, states, rewards)
+
+The policy π decides the action (deadline hit/miss) based on the history of
+past actions, states, and rewards. It returns a single true/false value.
+"""
+function π(actions::Vector{Bool}, states::Vector{Vector{Float64}}, rewards::Vector{Float64})
+	## Example 1: return true when the distance to reference is greater than 1
+	# return rewards[end] <= -1
+	
+	## Example 2: return true when the distance increase consecutively for 3 steps
+	# return length(rewards) > 2 && (rewards[end-2] > rewards[end-1] > rewards[end])
+
+	## Example 3: return true when the utilization up to now is less than 0.5
+	return length(actions) > 0 && (sum(actions) / length(actions) < 0.5)
 end
 
 # ╔═╡ 8015eee9-cfe9-4890-a3a5-e3f97517d1d2
@@ -54,11 +71,11 @@ md"""
 
 	Some of the policies are defined with the [compact function declaration syntax](https://docs.julialang.org/en/v1/manual/functions/#man-functions), which is equivalent to the normal syntax. I.e., the following two declarations are equivalent:
 	```julia
-	π₀(state::Vector{Float64}, reward::Float64)::Bool = true
+	π₀(states::Vector{Vector{Float64}}, rewards::Vector{Float64})::Bool = true
 	```
 	and
 	```julia
-	function π₀(state::Vector{Float64}, reward::Float64)::Bool
+	function π₀(states::Vector{Vector{Float64}}, rewards::Vector{Float64})::Bool
 		return true
 	end
 	```
@@ -77,28 +94,34 @@ Define the sampling period $T$ and time horizon $H$
 const T = 0.02
 
 # ╔═╡ 837c7cf2-66cb-4ebe-a417-df1e5da9cc73
-const H = 100
+const H = 500
 
 # ╔═╡ 2fee3edd-bba5-4738-a43c-691c9b4cf3de
 md"""
-Initiate the simulation environment
+Display all available models.
+"""
+
+# ╔═╡ 64bf8494-2e6c-4ad7-bffa-cf4a6ae74456
+benchmarks
+
+# ╔═╡ 84f2e971-241e-4895-9daf-18a65de77ea5
+md"""
+Convert a chosen model from continuous to discrete form using sampling period $T$ = $T
 """
 
 # ╔═╡ a274cbd6-13c3-499f-8407-41211e25dae1
-sys = c2d(benchmarks[:F1], T)
+sys = c2d(benchmarks[:CC], T)
 
-# ╔═╡ 4f63bf67-8208-4742-8dee-aa3186c8d658
-env = let π
-	Environment(sys)
-end
-
-# ╔═╡ e8e8964c-c829-4ba4-8cbb-230eec2faffa
+# ╔═╡ 4730f9cd-493d-42ea-9006-013a746a149f
 md"""
-Simulate the system for $H$ steps
+Initiate the simulation environment and Simulate the system for $H$ steps.
 """
 
 # ╔═╡ cbd51753-b04a-40c9-8f5b-9b88c74fc6f7
-states, rewards, ideal_states = sim!(env, π, H)
+actions, states, rewards, ideal_states = let 
+	env = Environment(sys)
+	sim!(env, π, H)
+end
 
 # ╔═╡ 09e3258a-a3fe-43a0-8f65-0d4a13b5c513
 md"""
@@ -163,13 +186,14 @@ plotH(rewards)
 # ╠═311337a7-9402-4ade-8707-e9ba9b72fa3b
 # ╠═837c7cf2-66cb-4ebe-a417-df1e5da9cc73
 # ╟─2fee3edd-bba5-4738-a43c-691c9b4cf3de
+# ╠═64bf8494-2e6c-4ad7-bffa-cf4a6ae74456
+# ╟─84f2e971-241e-4895-9daf-18a65de77ea5
 # ╠═a274cbd6-13c3-499f-8407-41211e25dae1
-# ╠═4f63bf67-8208-4742-8dee-aa3186c8d658
-# ╟─e8e8964c-c829-4ba4-8cbb-230eec2faffa
+# ╟─4730f9cd-493d-42ea-9006-013a746a149f
 # ╠═cbd51753-b04a-40c9-8f5b-9b88c74fc6f7
 # ╟─09e3258a-a3fe-43a0-8f65-0d4a13b5c513
 # ╠═45b657ae-6220-44b3-aa35-cae27bf730b0
-# ╠═eb39929a-46b6-4d53-a3e9-30af17500b54
+# ╟─eb39929a-46b6-4d53-a3e9-30af17500b54
 # ╠═19634c38-ec2c-45a0-862a-3f92beecb5a1
 # ╟─d9b853f3-4f79-487e-98ef-2f1b321b9d69
 # ╠═66fbe369-33e7-409f-ae66-29c1984518b3

--- a/src/sim.jl
+++ b/src/sim.jl
@@ -35,12 +35,13 @@ function step!(env::Environment, action::Bool)
 end
 
 """
-    sim(env, π, H)
+    sim!(env, π, H)
 
 Simulate the environment for `H` steps using policy `π`.
-Returns two vectors containing the states and rewards for each step.
+Returns vectors containing the actions, states, rewards, and ideal states, respectively.
 """
-function sim!(env::Environment, π::Function, H::Int)
+function sim!(env::Environment, π::Function, H::Integer)
+    actions = Vector{Bool}(undef, H)
     states = Vector{Vector{Float64}}(undef, H + 1)
     rewards = Vector{Float64}(undef, H + 1)
     ideal_states = Vector{Vector{Float64}}(undef, H + 1)
@@ -50,12 +51,12 @@ function sim!(env::Environment, π::Function, H::Int)
     ideal_states[1] = env.ideal_state
     
     for t in 1:H
-        action = π(states[t], rewards[t])
-        states[t + 1], rewards[t + 1] = step!(env, action)
+        actions[t] = π(actions[1:t-1], states[1:t], rewards[1:t])
+        states[t + 1], rewards[t + 1] = step!(env, actions[t])
         ideal_states[t + 1] = env.ideal_state
     end
     
-    return stack(states), rewards, stack(ideal_states)
+    return actions, stack(states), rewards, stack(ideal_states)
 end
 
 """
@@ -81,6 +82,6 @@ end
 
 A convenience function that returns an initial state with the correct dimensions for the plant.
 """
-function make_x0(sys::StateSpace)::Vector{Float64}
+function make_x0(sys::StateSpace)
     return repeat([1.], sys.nx)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,8 +17,9 @@ using ControlRL
     @test r ≈ 0.0 atol=1e-5
 
     env2 = Environment(sys)
-    states, rewards = sim!(env2, (s, r) -> true, H)
+    actions, states, rewards = sim!(env2, (a, s, r) -> true, H)
 
+    @test actions == fill(true, H)
     @test states[:, end] == s
     @test rewards[end] == r
 end


### PR DESCRIPTION
**The API between `sim!()` and `π()` have been changed.** The simulation function `sim!()` now expects the policy function `π()` to have three inputs: `actions`, `states`, and `rewards`, which contains the full history of the simulation up to the current time step.